### PR TITLE
Rejson deleting key crashes the rejson server

### DIFF
--- a/rejson.go
+++ b/rejson.go
@@ -190,8 +190,8 @@ func JSONMGet(conn redis.Conn, path string, keys ...string) (res interface{}, er
 
 // JSONDel to delete a json object
 // JSON.DEL <key> <path>
-func JSONDel(conn redis.Conn, key string, path string) (res interface{}, err error) {
-	name, args, _ := CommandBuilder("JSON.DEL", key, path)
+func JSONDel(conn redis.Conn, key string) (res interface{}, err error) {
+	name, args, _ := CommandBuilder("JSON.DEL", key)
 	return conn.Do(name, args...)
 }
 

--- a/rejson_test.go
+++ b/rejson_test.go
@@ -318,7 +318,7 @@ func TestJSONDel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONDel(tt.args.conn, tt.args.key, tt.args.path)
+			gotRes, err := JSONDel(tt.args.conn, tt.args.key)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("JSONDel() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
*Rejson deleting key crashes the rejson server*

- Reason:  JSONDel it takes the argument path which causes it to crash.  


https://oss.redislabs.com/rejson/commands/ Says
`path defaults to root if not provided. Non-existing keys and paths are ignored. Deleting an object's root is equivalent to deleting the key from Redis.`

So we don't need to define the path explicitly. And its working fine for me.