### PR TITLE
Add gometalinter to travis ci #20

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - scopelint
     - gochecknoglobals
     - dupl
     - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ linters-settings:
   golint:
     min-confidence: 0
   gocyclo:
-    min-complexity: 10
+    min-complexity: 15
   maligned:
     suggest-new: true
   goconst:
@@ -18,14 +18,9 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - prealloc
-    - gosec
     - gochecknoglobals
     - dupl
-    - gocyclo
     - unparam
-    - scopelint
-    - gocritic
 
 run:
   skip-dirs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,33 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 10
+  maligned:
+    suggest-new: true
+  goconst:
+    min-len: 3
+    min-occurrences: 3
+  misspell:
+    locale: US
+  lll:
+    line-length: 120
+
+linters:
+  enable-all: true
+  disable:
+    - prealloc
+    - gosec
+    - gochecknoglobals
+    - dupl
+    - gocyclo
+    - unparam
+    - scopelint
+    - gocritic
+
+run:
+  skip-dirs:
+    - vendor 
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,15 @@ before_install:
 
 install:
   - dep ensure
+  - go get github.com/alecthomas/gometalinter
+  - gometalinter --install --vendored-linters
 
 script:
   - go test -v .
   - go test -covermode=count -coverprofile=profile.cov .
   - go vet -x .
   - staticcheck .
+  - gometalinter --concurrency=4 --enable-gc --deadline=300s --disable-all --enable=deadcode --enable=errcheck --enable=goconst --enable=gofmt --enable=goimports --enable=golint --exclude=.pb.go --enable=gotype --enable=ineffassign --enable=interfacer --enable=lll --line-length=120 --enable=misspell --enable=structcheck --enable=unconvert --enable=unused --enable=varcheck --enable=vet --enable=maligned --vendor ./...
 
 after_script:
   - $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ before_install:
 
 install:
   - dep ensure
-  - go get github.com/alecthomas/gometalinter
-  - gometalinter --install --vendored-linters
 
 script:
   - go test -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,15 @@ before_install:
   - go get honnef.co/go/tools/cmd/staticcheck
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.12.5
 
 install:
   - dep ensure
-  - go get github.com/alecthomas/gometalinter
-  - gometalinter --install --vendored-linters
 
 script:
   - go test -v .
   - go test -covermode=count -coverprofile=profile.cov .
-  - go vet -x .
-  - staticcheck .
-  - gometalinter --concurrency=4 --enable-gc --deadline=300s --disable-all --enable=deadcode --enable=errcheck --enable=goconst --enable=gofmt --enable=goimports --enable=golint --exclude=.pb.go --enable=gotype --enable=ineffassign --enable=interfacer --enable=lll --line-length=120 --enable=misspell --enable=structcheck --enable=unconvert --enable=unused --enable=varcheck --enable=vet --enable=maligned --vendor ./...
+  - golangci-lint run ./...
 
 after_script:
   - $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_install:
 
 install:
   - dep ensure
+  - go get github.com/alecthomas/gometalinter
+  - gometalinter --install --vendored-linters
 
 script:
   - go test -v .

--- a/examples/json_array/json_array.go
+++ b/examples/json_array/json_array.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
+
 	"github.com/gomodule/redigo/redis"
 	"github.com/nitishm/go-rejson"
-	"log"
 )
 
 func main() {
@@ -19,8 +20,11 @@ func main() {
 		log.Fatalf("Failed to connect to redis-server @ %s", *addr)
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			log.Fatalf("Failed to communicate to redis-server @ %v", err)
+		}
 	}()
 
 	ArrIn := []string{"one", "two", "three", "four", "five"}
@@ -85,28 +89,28 @@ func main() {
 
 	res, err = rejson.JSONArrIndex(conn, "arr", ".", "one")
 	if err != nil {
-		log.Fatalf("Failed to JSONArrIndex", err)
+		log.Fatalf("Failed to JSONArrIndex %v", err)
 		return
 	}
 	fmt.Println("Index of \"one\":", res)
 
 	res, err = rejson.JSONArrIndex(conn, "arr", ".", "three", 3, 10)
 	if err != nil {
-		log.Fatalf("Failed to JSONArrIndex", err)
+		log.Fatalf("Failed to JSONArrIndex %v", err)
 		return
 	}
 	fmt.Println("Out of range:", res)
 
 	res, err = rejson.JSONArrIndex(conn, "arr", ".", "ten")
 	if err != nil {
-		log.Fatalf("Failed to JSONArrIndex", err)
+		log.Fatalf("Failed to JSONArrIndex %v", err)
 		return
 	}
 	fmt.Println("\"ten\" not found:", res)
 
 	res, err = rejson.JSONArrTrim(conn, "arr", ".", 1, 2)
 	if err != nil {
-		log.Fatalf("Failed to JSONArrTrim", err)
+		log.Fatalf("Failed to JSONArrTrim %v", err)
 		return
 	}
 	fmt.Println("no. of elements left:", res)
@@ -125,7 +129,7 @@ func main() {
 
 	res, err = rejson.JSONArrInsert(conn, "arr", ".", 0, "one")
 	if err != nil {
-		log.Fatalf("Failed to JSONArrInsert", err)
+		log.Fatalf("Failed to JSONArrInsert %v", err)
 		return
 	}
 	fmt.Println("no. of elements:", res)

--- a/examples/json_obj/json_obj.go
+++ b/examples/json_obj/json_obj.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
+
 	"github.com/gomodule/redigo/redis"
 	"github.com/nitishm/go-rejson"
-	"log"
 )
 
 func main() {
@@ -19,8 +20,11 @@ func main() {
 		log.Fatalf("Failed to connect to redis-server @ %s", *addr)
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			log.Fatalf("Failed to communicate to redis-server @ %v", err)
+		}
 	}()
 
 	type Object struct {

--- a/examples/json_set/json_set.go
+++ b/examples/json_set/json_set.go
@@ -32,8 +32,11 @@ func main() {
 		log.Fatalf("Failed to connect to redis-server @ %s", *addr)
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			log.Fatalf("Failed to communicate to redis-server @ %v", err)
+		}
 	}()
 
 	student := Student{

--- a/rejson.go
+++ b/rejson.go
@@ -15,7 +15,7 @@ const (
 	DebugMemorySubcommand = "MEMORY"
 	// DebugHelpSubcommand provide the corresponding HELP sub commands for JSONDebug
 	DebugHelpSubcommand = "HELP"
-	// DebugHelpOutput is the ouput of command JSON.Debug HELP <obj> [path]
+	// DebugHelpOutput is the output of command JSON.Debug HELP <obj> [path]
 	DebugHelpOutput = "MEMORY <key> [path] - reports memory usage\nHELP                - this message"
 )
 
@@ -252,7 +252,8 @@ func commandJSONDebug(argsIn ...interface{}) (argsOut []interface{}, err error) 
 // CommandBuilder is used to build a command that can be used directly with redigo's conn.Do()
 // This is especially useful if you do not need to conn.Do() and instead need to use the JSON.* commands in a
 // MUTLI/EXEC scenario along with some other operations like GET/SET/HGET/HSET/...
-func CommandBuilder(commandNameIn string, argsIn ...interface{}) (commandNameOut string, argsOut []interface{}, err error) {
+func CommandBuilder(commandNameIn string, argsIn ...interface{}) (commandNameOut string,
+	argsOut []interface{}, err error) {
 	cmd, ok := commandMux[commandNameIn]
 	if !ok {
 		return commandNameOut, nil, fmt.Errorf("command %s not supported by ReJSON", commandNameIn)
@@ -306,7 +307,7 @@ func JSONGet(conn redis.Conn, key string, path string, opts ...JSONGetOption) (r
 // JSON.MGET <key> [key ...] <path>
 func JSONMGet(conn redis.Conn, path string, keys ...string) (res interface{}, err error) {
 	if len(keys) == 0 {
-		err = fmt.Errorf("need atlesat one key as an argument")
+		err = fmt.Errorf("need atleast one key as an argument")
 		return nil, err
 	}
 
@@ -365,7 +366,7 @@ func JSONStrLen(conn redis.Conn, key string, path string) (res interface{}, err 
 // JSON.ARRAPPEND <key> <path> <json> [json ...]
 func JSONArrAppend(conn redis.Conn, key string, path string, values ...interface{}) (res interface{}, err error) {
 	if len(values) == 0 {
-		err = fmt.Errorf("need atlesat one value string as an argument")
+		err = fmt.Errorf("need atleast one value string as an argument")
 		return nil, err
 	}
 
@@ -393,7 +394,8 @@ func JSONArrPop(conn redis.Conn, key, path string, index int) (res interface{}, 
 
 // JSONArrIndex returns the index of the json element provided and return -1 if element is not present
 // JSON.ARRINDEX <key> <path> <json-scalar> [start [stop]]
-func JSONArrIndex(conn redis.Conn, key, path string, jsonValue interface{}, optionalRange ...int) (res interface{}, err error) {
+func JSONArrIndex(conn redis.Conn, key, path string,
+	jsonValue interface{}, optionalRange ...int) (res interface{}, err error) {
 	args := []interface{}{key, path, jsonValue}
 
 	ln := len(optionalRange)
@@ -419,7 +421,7 @@ func JSONArrTrim(conn redis.Conn, key, path string, start, end int) (res interfa
 // JSON.ARRINSERT <key> <path> <index> <json> [json ...]
 func JSONArrInsert(conn redis.Conn, key, path string, index int, values ...interface{}) (res interface{}, err error) {
 	if len(values) == 0 {
-		err = fmt.Errorf("need atlesat one value string as an argument")
+		err = fmt.Errorf("need atleast one value string as an argument")
 		return nil, err
 	}
 

--- a/rejson.go
+++ b/rejson.go
@@ -399,11 +399,12 @@ func JSONArrIndex(conn redis.Conn, key, path string,
 	args := []interface{}{key, path, jsonValue}
 
 	ln := len(optionalRange)
-	if ln > 2 {
+	switch {
+	case ln > 2:
 		return nil, fmt.Errorf("need atmost two integeral value as an argument representing array range")
-	} else if ln == 1 { // only inclusive start is present
+	case ln == 1: // only inclusive start is present
 		args = append(args, optionalRange[0])
-	} else if ln == 2 { // both inclusive start and exclusive end are present
+	case ln == 2: // both inclusive start and exclusive end are present
 		args = append(args, optionalRange[0], optionalRange[1])
 	}
 	name, args, _ := CommandBuilder("JSON.ARRINDEX", args...)

--- a/rejson_test.go
+++ b/rejson_test.go
@@ -20,8 +20,11 @@ func TestJSONSet(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	testObj := TestObject{
@@ -159,8 +162,11 @@ func TestJSONGet(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "kstr", ".", "simplestring", false, false)
@@ -266,8 +272,11 @@ func TestJSONDel(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "kstr", ".", "simplestring", false, false)
@@ -358,8 +367,11 @@ func TestJSONMGet(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "kstr", ".", "simplestring", false, false)
@@ -489,8 +501,11 @@ func TestJSONType(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "kstr", ".", "simplestring", false, false)
@@ -581,8 +596,11 @@ func TestJSONNumIncrBy(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "kint", ".", 1, false, false)
@@ -683,8 +701,11 @@ func TestJSONNumMultBy(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "kint", ".", 2, false, false)
@@ -785,8 +806,11 @@ func TestJSONStrAppend(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "kstr", ".", "simplestring", false, false)
@@ -871,8 +895,11 @@ func TestJSONStrLen(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "kstr", ".", "simplestring", false, false)
@@ -953,8 +980,11 @@ func TestJSONArrAppend(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	values := make([]interface{}, 0)
@@ -1033,8 +1063,11 @@ func TestJSONArrLen(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	values := make([]interface{}, 0)
@@ -1104,8 +1137,11 @@ func TestJSONArrPop(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	values := make([]interface{}, 0)
@@ -1198,8 +1234,11 @@ func TestJSONArrIndex(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	values := make([]interface{}, 0)
@@ -1312,8 +1351,11 @@ func TestJSONArrTrim(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	values := make([]interface{}, 0)
@@ -1392,8 +1434,11 @@ func TestJSONArrInsert(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	values := make([]interface{}, 0)
@@ -1498,8 +1543,11 @@ func TestJSONObjLen(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	type Object struct {
@@ -1570,8 +1618,11 @@ func TestJSONObjKeys(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	type Object struct {
@@ -1642,8 +1693,11 @@ func TestJSONDebug(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "tstr", ".", "SimpleString", false, false)
@@ -1706,8 +1760,11 @@ func TestJSONForget(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "kstr", ".", "simplestring", false, false)
@@ -1798,8 +1855,11 @@ func TestJSONResp(t *testing.T) {
 		return
 	}
 	defer func() {
-		conn.Do("FLUSHALL")
-		conn.Close()
+		_, err = conn.Do("FLUSHALL")
+		err = conn.Close()
+		if err != nil {
+			t.Fatal("Failed to communicate to redis-server")
+		}
 	}()
 
 	_, err = JSONSet(conn, "tstr", ".", "SimpleString", false, false)

--- a/rejson_test.go
+++ b/rejson_test.go
@@ -142,14 +142,15 @@ func TestJSONSet(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONSet(conn, tt.args.key, tt.args.path, tt.args.obj, tt.args.NX, tt.args.XX)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONSet() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONSet(conn, ttt.args.key, ttt.args.path, ttt.args.obj, ttt.args.NX, ttt.args.XX)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONSet() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONSet() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONSet() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -252,14 +253,15 @@ func TestJSONGet(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONGet(tt.args.conn, tt.args.key, tt.args.path, tt.args.options...)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONGet() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONGet(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.options...)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONGet() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("\nJSONGet() = %v,\nwant      = %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("\nJSONGet() = %v,\nwant      = %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -347,14 +349,15 @@ func TestJSONDel(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONDel(tt.args.conn, tt.args.key, tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONDel() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONDel(ttt.args.conn, ttt.args.key, ttt.args.path)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONDel() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONDel() = %t, want %t", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONDel() = %t, want %t", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -473,14 +476,15 @@ func TestJSONMGet(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONMGet(tt.args.conn, tt.args.path, tt.args.keys...)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONMGet() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONMGet(ttt.args.conn, ttt.args.path, ttt.args.keys...)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONMGet() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONMGet() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONMGet() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -576,14 +580,15 @@ func TestJSONType(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONType(tt.args.conn, tt.args.key, tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONType() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONType(ttt.args.conn, ttt.args.key, ttt.args.path)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONType() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONType() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONType() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -681,14 +686,15 @@ func TestJSONNumIncrBy(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONNumIncrBy(tt.args.conn, tt.args.key, tt.args.path, tt.args.number)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONNumIncrBy() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONNumIncrBy(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.number)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONNumIncrBy() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONNumIncrBy() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONNumIncrBy() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -786,14 +792,15 @@ func TestJSONNumMultBy(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONNumMultBy(tt.args.conn, tt.args.key, tt.args.path, tt.args.number)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONNumMultBy() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONNumMultBy(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.number)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONNumMultBy() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONNumMultBy() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONNumMultBy() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -875,14 +882,15 @@ func TestJSONStrAppend(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONStrAppend(tt.args.conn, tt.args.key, tt.args.path, tt.args.jsonstring)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONStrAppend() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONStrAppend(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.jsonstring)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONStrAppend() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONStrAppend() = %v, want %t", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONStrAppend() = %v, want %t", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -960,14 +968,15 @@ func TestJSONStrLen(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONStrLen(tt.args.conn, tt.args.key, tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONStrLen() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONStrLen(ttt.args.conn, ttt.args.key, ttt.args.path)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONStrLen() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONStrLen() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONStrLen() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -1043,14 +1052,15 @@ func TestJSONArrAppend(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONArrAppend(tt.args.conn, tt.args.key, tt.args.path, tt.args.values...)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONArrAppend() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONArrAppend(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.values...)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONArrAppend() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONArrAppend() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONArrAppend() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -1117,14 +1127,15 @@ func TestJSONArrLen(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONArrLen(tt.args.conn, tt.args.key, tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONArrLen() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONArrLen(ttt.args.conn, ttt.args.key, ttt.args.path)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONArrLen() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONArrLen() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONArrLen() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -1206,21 +1217,22 @@ func TestJSONArrPop(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := JSONArrPop(tt.args.conn, tt.args.key, tt.args.path, tt.args.index)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONArrPop() error = %v, wantErr %v", err, tt.wantErr)
+			res, err := JSONArrPop(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.index)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONArrPop() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !tt.wantErr {
+			if !ttt.wantErr {
 				var gotRes interface{}
 				err = json.Unmarshal(res.([]byte), &gotRes)
 				if err != nil {
 					t.Errorf("JSONArrPop(): Failed to JSON Unmarshal")
 					return
 				}
-				if !reflect.DeepEqual(gotRes, tt.wantRes) {
-					t.Errorf("JSONArrPop() = %v, want %v", gotRes, tt.wantRes)
+				if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+					t.Errorf("JSONArrPop() = %v, want %v", gotRes, ttt.wantRes)
 				}
 			}
 		})
@@ -1328,16 +1340,17 @@ func TestJSONArrIndex(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
 
-			gotRes, err := JSONArrIndex(tt.args.conn, tt.args.key, tt.args.path, tt.args.value, tt.args.optionalRange...)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONArrIndex() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONArrIndex(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.value, ttt.args.optionalRange...)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONArrIndex() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !tt.wantErr {
-				if !reflect.DeepEqual(gotRes.(int64), tt.wantRes.(int64)) {
-					t.Errorf("JSONArrIndex() = %v, want %v", gotRes, tt.wantRes)
+			if !ttt.wantErr {
+				if !reflect.DeepEqual(gotRes.(int64), ttt.wantRes.(int64)) {
+					t.Errorf("JSONArrIndex() = %v, want %v", gotRes, ttt.wantRes)
 				}
 			}
 		})
@@ -1412,15 +1425,16 @@ func TestJSONArrTrim(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
 
-			gotRes, err := JSONArrTrim(tt.args.conn, tt.args.key, tt.args.path, tt.args.start, tt.args.end)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONArrTrim() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONArrTrim(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.start, ttt.args.end)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONArrTrim() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONArrTrim() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONArrTrim() = %v, want %v", gotRes, ttt.wantRes)
 			}
 
 		})
@@ -1511,25 +1525,26 @@ func TestJSONArrInsert(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONArrInsert(tt.args.conn, tt.args.key, tt.args.path, tt.args.index, tt.args.values...)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONArrInsert() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONArrInsert(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.index, ttt.args.values...)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONArrInsert() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONArrInsert() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONArrInsert() = %v, want %v", gotRes, ttt.wantRes)
 				return
 			}
 
-			if !tt.wantErr {
-				newArr, err := JSONGet(tt.args.conn, tt.args.key, tt.args.path)
+			if !ttt.wantErr {
+				newArr, err := JSONGet(ttt.args.conn, ttt.args.key, ttt.args.path)
 				if err != nil {
 					t.Errorf("JSONArrGet(): Failed to JSONGet")
 					return
 				}
-				if !reflect.DeepEqual(newArr.([]byte), tt.finalSliceGot) {
-					t.Errorf("JSONArrGet() = %v, want %v", newArr.([]byte), tt.finalSliceGot)
+				if !reflect.DeepEqual(newArr.([]byte), ttt.finalSliceGot) {
+					t.Errorf("JSONArrGet() = %v, want %v", newArr.([]byte), ttt.finalSliceGot)
 				}
 			}
 		})
@@ -1598,14 +1613,15 @@ func TestJSONObjLen(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONObjLen(tt.args.conn, tt.args.key, tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONObjLen() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONObjLen(ttt.args.conn, ttt.args.key, ttt.args.path)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONObjLen() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONObjLen() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONObjLen() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -1673,14 +1689,15 @@ func TestJSONObjKeys(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONObjKeys(tt.args.conn, tt.args.key, tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONObjKeys() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONObjKeys(ttt.args.conn, ttt.args.key, ttt.args.path)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONObjKeys() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONObjKeys() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONObjKeys() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -1740,14 +1757,15 @@ func TestJSONDebug(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONDebug(tt.args.conn, tt.args.subCommand, tt.args.key, tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONDebug() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONDebug(ttt.args.conn, ttt.args.subCommand, ttt.args.key, ttt.args.path)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONDebug() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONDebug() = %v, want %v", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONDebug() = %v, want %v", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -1835,14 +1853,15 @@ func TestJSONForget(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONForget(tt.args.conn, tt.args.key, tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONForget() error = %v, wantErr %v", err, tt.wantErr)
+			gotRes, err := JSONForget(ttt.args.conn, ttt.args.key, ttt.args.path)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONForget() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, tt.wantRes) {
-				t.Errorf("JSONForget() = %t, want %t", gotRes, tt.wantRes)
+			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
+				t.Errorf("JSONForget() = %t, want %t", gotRes, ttt.wantRes)
 			}
 		})
 	}
@@ -1887,10 +1906,11 @@ func TestJSONResp(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := JSONResp(tt.args.conn, tt.args.key, tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("JSONResp() error = %v, wantErr %v", err, tt.wantErr)
+			_, err := JSONResp(ttt.args.conn, ttt.args.key, ttt.args.path)
+			if (err != nil) != ttt.wantErr {
+				t.Errorf("JSONResp() error = %v, wantErr %v", err, ttt.wantErr)
 				return
 			}
 		})

--- a/rejson_test.go
+++ b/rejson_test.go
@@ -142,15 +142,14 @@ func TestJSONSet(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONSet(conn, ttt.args.key, ttt.args.path, ttt.args.obj, ttt.args.NX, ttt.args.XX)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONSet() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONSet(conn, tt.args.key, tt.args.path, tt.args.obj, tt.args.NX, tt.args.XX)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONSet() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONSet() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONSet() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -253,15 +252,14 @@ func TestJSONGet(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONGet(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.options...)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONGet() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONGet(tt.args.conn, tt.args.key, tt.args.path, tt.args.options...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONGet() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("\nJSONGet() = %v,\nwant      = %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("\nJSONGet() = %v,\nwant      = %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -349,15 +347,14 @@ func TestJSONDel(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONDel(ttt.args.conn, ttt.args.key, ttt.args.path)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONDel() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONDel(tt.args.conn, tt.args.key, tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONDel() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONDel() = %t, want %t", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONDel() = %t, want %t", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -476,15 +473,14 @@ func TestJSONMGet(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONMGet(ttt.args.conn, ttt.args.path, ttt.args.keys...)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONMGet() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONMGet(tt.args.conn, tt.args.path, tt.args.keys...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONMGet() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONMGet() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONMGet() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -580,15 +576,14 @@ func TestJSONType(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONType(ttt.args.conn, ttt.args.key, ttt.args.path)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONType() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONType(tt.args.conn, tt.args.key, tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONType() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONType() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONType() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -686,15 +681,14 @@ func TestJSONNumIncrBy(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONNumIncrBy(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.number)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONNumIncrBy() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONNumIncrBy(tt.args.conn, tt.args.key, tt.args.path, tt.args.number)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONNumIncrBy() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONNumIncrBy() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONNumIncrBy() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -792,15 +786,14 @@ func TestJSONNumMultBy(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONNumMultBy(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.number)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONNumMultBy() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONNumMultBy(tt.args.conn, tt.args.key, tt.args.path, tt.args.number)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONNumMultBy() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONNumMultBy() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONNumMultBy() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -882,15 +875,14 @@ func TestJSONStrAppend(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONStrAppend(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.jsonstring)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONStrAppend() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONStrAppend(tt.args.conn, tt.args.key, tt.args.path, tt.args.jsonstring)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONStrAppend() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONStrAppend() = %v, want %t", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONStrAppend() = %v, want %t", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -968,15 +960,14 @@ func TestJSONStrLen(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONStrLen(ttt.args.conn, ttt.args.key, ttt.args.path)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONStrLen() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONStrLen(tt.args.conn, tt.args.key, tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONStrLen() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONStrLen() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONStrLen() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -1052,15 +1043,14 @@ func TestJSONArrAppend(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONArrAppend(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.values...)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONArrAppend() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONArrAppend(tt.args.conn, tt.args.key, tt.args.path, tt.args.values...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONArrAppend() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONArrAppend() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONArrAppend() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -1127,15 +1117,14 @@ func TestJSONArrLen(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONArrLen(ttt.args.conn, ttt.args.key, ttt.args.path)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONArrLen() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONArrLen(tt.args.conn, tt.args.key, tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONArrLen() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONArrLen() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONArrLen() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -1217,22 +1206,21 @@ func TestJSONArrPop(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := JSONArrPop(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.index)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONArrPop() error = %v, wantErr %v", err, ttt.wantErr)
+			res, err := JSONArrPop(tt.args.conn, tt.args.key, tt.args.path, tt.args.index)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONArrPop() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !ttt.wantErr {
+			if !tt.wantErr {
 				var gotRes interface{}
 				err = json.Unmarshal(res.([]byte), &gotRes)
 				if err != nil {
 					t.Errorf("JSONArrPop(): Failed to JSON Unmarshal")
 					return
 				}
-				if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-					t.Errorf("JSONArrPop() = %v, want %v", gotRes, ttt.wantRes)
+				if !reflect.DeepEqual(gotRes, tt.wantRes) {
+					t.Errorf("JSONArrPop() = %v, want %v", gotRes, tt.wantRes)
 				}
 			}
 		})
@@ -1340,17 +1328,16 @@ func TestJSONArrIndex(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
 
-			gotRes, err := JSONArrIndex(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.value, ttt.args.optionalRange...)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONArrIndex() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONArrIndex(tt.args.conn, tt.args.key, tt.args.path, tt.args.value, tt.args.optionalRange...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONArrIndex() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !ttt.wantErr {
-				if !reflect.DeepEqual(gotRes.(int64), ttt.wantRes.(int64)) {
-					t.Errorf("JSONArrIndex() = %v, want %v", gotRes, ttt.wantRes)
+			if !tt.wantErr {
+				if !reflect.DeepEqual(gotRes.(int64), tt.wantRes.(int64)) {
+					t.Errorf("JSONArrIndex() = %v, want %v", gotRes, tt.wantRes)
 				}
 			}
 		})
@@ -1425,16 +1412,15 @@ func TestJSONArrTrim(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
 
-			gotRes, err := JSONArrTrim(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.start, ttt.args.end)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONArrTrim() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONArrTrim(tt.args.conn, tt.args.key, tt.args.path, tt.args.start, tt.args.end)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONArrTrim() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONArrTrim() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONArrTrim() = %v, want %v", gotRes, tt.wantRes)
 			}
 
 		})
@@ -1525,26 +1511,25 @@ func TestJSONArrInsert(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONArrInsert(ttt.args.conn, ttt.args.key, ttt.args.path, ttt.args.index, ttt.args.values...)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONArrInsert() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONArrInsert(tt.args.conn, tt.args.key, tt.args.path, tt.args.index, tt.args.values...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONArrInsert() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONArrInsert() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONArrInsert() = %v, want %v", gotRes, tt.wantRes)
 				return
 			}
 
-			if !ttt.wantErr {
-				newArr, err := JSONGet(ttt.args.conn, ttt.args.key, ttt.args.path)
+			if !tt.wantErr {
+				newArr, err := JSONGet(tt.args.conn, tt.args.key, tt.args.path)
 				if err != nil {
 					t.Errorf("JSONArrGet(): Failed to JSONGet")
 					return
 				}
-				if !reflect.DeepEqual(newArr.([]byte), ttt.finalSliceGot) {
-					t.Errorf("JSONArrGet() = %v, want %v", newArr.([]byte), ttt.finalSliceGot)
+				if !reflect.DeepEqual(newArr.([]byte), tt.finalSliceGot) {
+					t.Errorf("JSONArrGet() = %v, want %v", newArr.([]byte), tt.finalSliceGot)
 				}
 			}
 		})
@@ -1613,15 +1598,14 @@ func TestJSONObjLen(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONObjLen(ttt.args.conn, ttt.args.key, ttt.args.path)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONObjLen() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONObjLen(tt.args.conn, tt.args.key, tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONObjLen() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONObjLen() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONObjLen() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -1689,15 +1673,14 @@ func TestJSONObjKeys(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONObjKeys(ttt.args.conn, ttt.args.key, ttt.args.path)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONObjKeys() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONObjKeys(tt.args.conn, tt.args.key, tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONObjKeys() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONObjKeys() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONObjKeys() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -1757,15 +1740,14 @@ func TestJSONDebug(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONDebug(ttt.args.conn, ttt.args.subCommand, ttt.args.key, ttt.args.path)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONDebug() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONDebug(tt.args.conn, tt.args.subCommand, tt.args.key, tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONDebug() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONDebug() = %v, want %v", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONDebug() = %v, want %v", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -1853,15 +1835,14 @@ func TestJSONForget(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := JSONForget(ttt.args.conn, ttt.args.key, ttt.args.path)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONForget() error = %v, wantErr %v", err, ttt.wantErr)
+			gotRes, err := JSONForget(tt.args.conn, tt.args.key, tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONForget() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotRes, ttt.wantRes) {
-				t.Errorf("JSONForget() = %t, want %t", gotRes, ttt.wantRes)
+			if !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("JSONForget() = %t, want %t", gotRes, tt.wantRes)
 			}
 		})
 	}
@@ -1906,11 +1887,10 @@ func TestJSONResp(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ttt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := JSONResp(ttt.args.conn, ttt.args.key, ttt.args.path)
-			if (err != nil) != ttt.wantErr {
-				t.Errorf("JSONResp() error = %v, wantErr %v", err, ttt.wantErr)
+			_, err := JSONResp(tt.args.conn, tt.args.key, tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONResp() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})


### PR DESCRIPTION
#20 
I added in gometalinter to travisci in this repo.
Gometalinter uses the following lint method.
```
gometalinter --concurrency=4 --enable-gc --deadline=300s --disable-all 
--enable=deadcode
--enable=errcheck
--enable=goconst
--enable=gofmt 
--enable=goimports
--enable=golint
--exclude=.pb.go
--enable=gotype
--enable=ineffassign
--enable=interfacer
--enable=lll --line-length=120 
--enable=misspell 
--enable=structcheck 
--enable=unconvert 
--enable=unused 
--enable=varcheck 
--enable=vet 
--enable=maligned 
--vendor ./...
```
https://github.com/alecthomas/gometalinter#supported-linters

I would like to know whether you want to use supported linters else.