### PR TITLE
Fix encoding to work with Cyrillic and Portuguese accentuation

### DIFF
--- a/rjs/helper.go
+++ b/rjs/helper.go
@@ -20,9 +20,7 @@ func StringToBytes(lst interface{}) (by []byte) {
 	if !ok {
 		panic("error: something went wrong")
 	}
-	for _, s := range _lst {
-		by = append(by, byte(s))
-	}
+	by = []byte(_lst)
 	return
 }
 


### PR DESCRIPTION
# Context

As we know in the issue #56  some characters when read from the database are not being processing as valid UTF-8 Characters. So this fixes it to handle the full length of the data representation for them 

Closes #56 