### PR TITLE
Change go-redis client to universal client interface

### DIFF
--- a/clients/goredis.go
+++ b/clients/goredis.go
@@ -12,7 +12,7 @@ import (
 // GoRedis implements ReJSON interface for Go-Redis/Redis Redis client
 // Link: https://github.com/go-redis/redis
 type GoRedis struct {
-	Conn *goredis.Client // import goredis "github.com/go-redis/redis/v8"
+	Conn goredis.UniversalClient // import goredis "github.com/go-redis/redis/v8"
 
 	// ctx defines context for the provided connection
 	ctx context.Context
@@ -20,7 +20,7 @@ type GoRedis struct {
 
 // NewGoRedisClient returns a new GoRedis ReJSON client with the provided context
 // and connection, if ctx is nil default context.Background will be used
-func NewGoRedisClient(ctx context.Context, conn *goredis.Client) *GoRedis {
+func NewGoRedisClient(ctx context.Context, conn goredis.UniversalClient) *GoRedis {
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/rejson_test.go
+++ b/rejson_test.go
@@ -45,7 +45,9 @@ func (t *TestClient) init() []helper {
 	}
 
 	// GoRedis Test Client
-	goredisCli := goredis.NewClient(&goredis.Options{Addr: "localhost:6379"})
+	goredisCli := goredis.NewUniversalClient(&goredis.UniversalOptions{
+		Addrs: []string{"localhost:6379"},
+	})
 
 	return []helper{
 		{cli: redigoCli, name: "Redigo ", closeFunc: func() {
@@ -76,7 +78,7 @@ func (t *TestClient) SetTestingClient(conn interface{}) {
 	case redigo.Conn:
 		t.name = "Redigo-"
 		t.rh.SetRedigoClient(conn)
-	case *goredis.Client:
+	case goredis.UniversalClient:
 		t.name = "GoRedis-"
 		t.rh.SetGoRedisClient(conn)
 	default:

--- a/rjs/options.go
+++ b/rjs/options.go
@@ -39,7 +39,7 @@ func (g GetOption) Value() []interface{} {
 }
 
 // SetValue will set the values in the options
-func (g GetOption) SetValue(arg string) {
+func (g *GetOption) SetValue(arg string) {
 	g.Arg = arg
 }
 

--- a/set_client.go
+++ b/set_client.go
@@ -31,13 +31,13 @@ func (r *Handler) SetRedigoClient(conn redigo.Conn) {
 
 // SetGoRedisClient sets Go-Redis (https://github.com/go-redis/redis) client to
 // the handler. It is left for backward compatibility.
-func (r *Handler) SetGoRedisClient(conn *goredis.Client) {
-	r.SetGoRedisClientWithContext(context.TODO(), conn)
+func (r *Handler) SetGoRedisClient(conn goredis.UniversalClient) {
+	r.SetGoRedisClientWithContext(context.Background(), conn)
 }
 
 // SetGoRedisClientWithContext sets Go-Redis (https://github.com/go-redis/redis) client to
 // the handler with a global context for the connection
-func (r *Handler) SetGoRedisClientWithContext(ctx context.Context, conn *goredis.Client) {
+func (r *Handler) SetGoRedisClientWithContext(ctx context.Context, conn goredis.UniversalClient) {
 	r.clientName = "goredis"
 	r.implementation = clients.NewGoRedisClient(ctx, conn)
 }


### PR DESCRIPTION
Checking ClusterClient support with go-redis [`UniversalClient`](https://pkg.go.dev/github.com/go-redis/redis/v8#UniversalClient)

Closes #53
